### PR TITLE
Adds FoldlM to Fcf/Control/Monad.hs

### DIFF
--- a/src/Fcf/Control/Monad.hs
+++ b/src/Fcf/Control/Monad.hs
@@ -290,6 +290,30 @@ type instance Eval (ForM ta f) = Eval (MapM f ta)
 
 
 --------------------------------------------------------------------------------
+-- FoldlM
+
+-- | FoldlM
+--
+-- === __Example__
+--
+-- >>> import GHC.TypeLits as TL (Symbol, type (-))
+-- >>> data Lambda :: Nat -> Nat -> Exp (Either Symbol Nat)
+-- >>> type instance Eval (Lambda a b) = If (Eval (a >= b)) ('Right (a TL.- b)) ('Left "Nat cannot be negative")
+-- >>> :kind! Eval (FoldlM Lambda 5 '[1,1,1])
+-- Eval (FoldlM Lambda 5 '[1,1,1]) :: Either Symbol Nat
+-- = 'Right 2
+-- >>> :kind! Eval (FoldlM Lambda 5 '[1,4,1])
+-- Eval (FoldlM Lambda 5 '[1,4,1]) :: Either Symbol Nat
+-- = 'Left "Nat cannot be negative"
+--
+data FoldlM :: (b -> a -> Exp (m b)) -> b -> t a -> Exp (m b)
+type instance Eval (FoldlM f z0 xs) = Eval ((Eval (Foldr (FoldlMHelper f) Return xs)) z0)
+
+-- | Helper for 'FoldlM'
+data FoldlMHelper :: (b -> a -> Exp (m b)) -> a -> (b -> Exp (m b)) -> Exp (b -> Exp (m b))
+type instance Eval (FoldlMHelper f a b) = Flip (>>=) b <=< Flip f a
+
+--------------------------------------------------------------------------------
 -- Traversable
 
 

--- a/src/Fcf/Data/Set.hs
+++ b/src/Fcf/Data/Set.hs
@@ -343,7 +343,8 @@ type instance Eval (SelectWithBools elms bls) =
 --        'Set '["a", "b", "c"]]
 --
 -- >>> :kind! Eval (PowerSet =<< FromList '[Int, Char, Maybe Int])
--- Eval (PowerSet =<< FromList '[Int, Char, Maybe Int]) :: Set (Set *)
+-- Eval (PowerSet =<< FromList '[Int, Char, Maybe Int]) :: Set
+--                                                           (Set (*))
 -- = 'Set
 --     '[ 'Set '[], 'Set '[Maybe Int], 'Set '[Char],
 --        'Set '[Char, Maybe Int], 'Set '[Int], 'Set '[Int, Char],

--- a/test/doctest.hs
+++ b/test/doctest.hs
@@ -10,4 +10,4 @@ exts =
   ]
 
 main :: IO ()
-main = doctest $ exts ++ ["-isrc"]
+main = doctest $ exts ++ ["src"]


### PR DESCRIPTION
This adds `FoldlM`. I'm not sure if we should just call it `FoldM` or move `FoldlM` to Fcf.Class.Foldable to mirror `Data.Foldable` and make `FoldM = FoldlM` in Fcf.Control.Monad.

I noticed the doctest test was not testing the documentation so I changed `["-isrc"]` to `["src"]`. I am running `cabal test` inside a nix-shell provided the` shell.nix. 