### PR TITLE
Add KnownVal instance to Show Typeable Type

### DIFF
--- a/src/Fcf/Data/Reflect.hs
+++ b/src/Fcf/Data/Reflect.hs
@@ -31,6 +31,8 @@ import qualified GHC.TypeLits as TL
 import           GHC.TypeLits (Nat, Symbol, KnownNat, KnownSymbol)
 import           Data.String (fromString, IsString)
 import           Data.Proxy
+import           Data.Typeable (Typeable, typeRep)
+import           Data.Kind (Type)
 -- import qualified Data.Map.Strict as MS
 import qualified Data.Map as DM
 import qualified Data.IntMap.Strict as IMS
@@ -96,8 +98,11 @@ instance (KnownNat n, Num a) => KnownVal a (n :: Nat) where
 instance KnownVal Bool 'True where fromType _ = True
 instance KnownVal Bool 'False where fromType _ = False
 
-instance (IsString str, KnownSymbol s) => KnownVal str (s :: Symbol )where
+instance (IsString str, KnownSymbol s) => KnownVal str (s :: Symbol) where
     fromType _ = fromString $ TL.symbolVal (Proxy @s)
+
+instance (IsString str, Typeable typ) => KnownVal str (typ :: Type) where
+    fromType = fromString . show . typeRep
 
 #if __GLASGOW_HASKELL__ >= 902
 

--- a/test/Test/Data/Reflect.hs
+++ b/test/Test/Data/Reflect.hs
@@ -19,6 +19,7 @@ import qualified Data.Text as DTxt
 #endif
 import           Data.Proxy
 import           Test.Hspec (describe, it, shouldBe, Spec)
+import           Data.Kind (Type)
 
 import           Fcf (Eval, type (=<<))
 import qualified Fcf.Data.Set as FS
@@ -39,6 +40,7 @@ spec = describe "Reflect" $ do
   specMaybeEither
   specStructures
   specTrees
+  specShowTypeable
   
 specBool :: Spec
 specBool = describe "Bool" $ do
@@ -254,3 +256,19 @@ specTrees = describe "Tree structures" $ do
           [DT.Node (Right "six") []
           ]
         ]
+
+data Test = Test Type Type
+
+specShowTypeable :: Spec
+specShowTypeable = describe "Show Type represented at the Kind level" $ do
+  it "Show Int" $ do
+    fromType @String (Proxy @Int)
+      `shouldBe`
+      "Int"
+  it "Show Set of Types" $ do
+    let test :: forall r. (r ~ Eval (FS.FromList '[Int, Maybe String, (), [Integer], IO ()])) 
+             => DS.Set String
+        test = fromType (Proxy @r)
+    test 
+      `shouldBe` 
+      DS.fromList ["Int", "Maybe [Char]", "()", "[Integer]", "IO ()"]

--- a/test/Test/Data/Reflect.hs
+++ b/test/Test/Data/Reflect.hs
@@ -19,7 +19,6 @@ import qualified Data.Text as DTxt
 #endif
 import           Data.Proxy
 import           Test.Hspec (describe, it, shouldBe, Spec)
-import           Data.Kind (Type)
 
 import           Fcf (Eval, type (=<<))
 import qualified Fcf.Data.Set as FS
@@ -256,8 +255,6 @@ specTrees = describe "Tree structures" $ do
           [DT.Node (Right "six") []
           ]
         ]
-
-data Test = Test Type Type
 
 specShowTypeable :: Spec
 specShowTypeable = describe "Show Type represented at the Kind level" $ do


### PR DESCRIPTION
I needed a way to show a Kind that contained some `Type`, so I added a `KnowVal` instance that shows any `Typeable` `Type`. I do not think there is another meaningful `KnownVal` instance we could have for `Type` given that `Type` has no value at the kind level.

(I'll try to send smaller PR to make them easier to merge)