### PR TITLE
Adds ErrorMessage, Char, IntMap, Map and Set instances

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,8 @@
       # filter = import nix-filter { };
 
       ghcVersion = "925";
+      # ghcVersion = "92";
+      # ghcVersion = "902";
 
       src = nix-filter.lib {
         root = ./.;
@@ -65,5 +67,6 @@
         library = fcf-containers;
         # packages.x86_64-linux.default = ;
         devShell.x86_64-linux = shell;
+        inherit pkgs;
       };
 }

--- a/src/Fcf/Data/Reflect.hs
+++ b/src/Fcf/Data/Reflect.hs
@@ -60,35 +60,6 @@ import qualified Fcf.Data.Tree as FT
 
 --------------------------------------------------------------------------------
 
-
--- | Reflect a list of Nats
---
--- Note that you may also use the KnownVal methods given below.
---
--- This method is taken from
--- https://hackage.haskell.org/package/numhask-array-0.10.1/docs/src/NumHask.Array.Shape.html#natVals
---
--- === __Example__
---
--- >>> :{
--- afun :: forall n. (n ~ '[1,2,3,4]) => [Int]
--- afun = natVals @n Proxy
--- :}
---
--- >>> afun
--- [1,2,3,4]
-class KnownNats (ns :: [Nat]) where
-  natVals :: Proxy ns -> [Int]
-
-instance KnownNats '[] where
-  natVals _ = []
-
-instance (TL.KnownNat n, KnownNats ns) => KnownNats (n : ns) where
-  natVals _ = fromInteger (TL.natVal (Proxy @n)) : natVals (Proxy @ns)
-
-
---------------------------------------------------------------------------------
-
 class KnownVal val kind where
     fromType :: Proxy kind -> val
 
@@ -97,9 +68,13 @@ instance (KnownNat n, Num a) => KnownVal a (n :: Nat) where
 
 instance KnownVal Bool 'True where fromType _ = True
 instance KnownVal Bool 'False where fromType _ = False
+instance KnownVal () '() where fromType _ = ()
 
 instance (IsString str, KnownSymbol s) => KnownVal str (s :: Symbol) where
     fromType _ = fromString $ TL.symbolVal (Proxy @s)
+
+instance (TL.KnownChar c) => KnownVal Char c where
+    fromType _ = TL.charVal (Proxy @c)
 
 instance (IsString str, Typeable typ) => KnownVal str (typ :: Type) where
     fromType = fromString . show . typeRep
@@ -120,7 +95,7 @@ instance (IsString str, Typeable typ) => KnownVal str (typ :: Type) where
 -- "hmm"
 instance (IsString str, KnownSymbol sym) => KnownVal str ('FTxt.Text sym)
   where
-    fromType _ = fromString $ fromType $ Proxy @sym 
+    fromType _ = fromType @str (Proxy @sym) 
 
 #endif
 
@@ -131,14 +106,14 @@ instance (IsString str, KnownSymbol sym) => KnownVal str ('FTxt.Text sym)
 instance KnownVal [a] '[] where
     fromType _ = []
 
-instance (KnownVal typ x, KnownVal [typ] xs) => KnownVal [typ] (x ': xs) where
+instance (KnownVal val x, KnownVal [val] xs) => KnownVal [val] (x ': xs) where
     fromType _ = fromType (Proxy @x) : fromType (Proxy @xs)
 
 --------------------------------------------------------------------------------
 
 -- Trees
 --
-instance (KnownVal typ k, KnownVal (T.Forest typ) trees) => KnownVal (T.Tree typ) ('FT.Node k trees)
+instance (KnownVal val k, KnownVal (T.Forest val) trees) => KnownVal (T.Tree val) ('FT.Node k trees)
   where
     fromType _ = T.Node (fromType (Proxy @k)) (fromType (Proxy @trees))
 
@@ -150,6 +125,10 @@ instance (KnownVal [(Int,val)] pairs) => KnownVal (IMS.IntMap val) ('NM.NatMap p
   where
     fromType _ = IMS.fromList (fromType (Proxy @pairs))
 
+instance (KnownVal [(Int,val)] pairs) => KnownVal (IMS.IntMap val) (pairs :: [(Nat, val')])
+  where
+    fromType _ = IMS.fromList (fromType (Proxy @pairs))
+
 --------------------------------------------------------------------------------
 
 -- Maps
@@ -158,11 +137,19 @@ instance (Ord key, KnownVal [(key,val)] pairs) => KnownVal (DM.Map key val) ('MC
   where
     fromType _ = DM.fromList (fromType (Proxy @pairs))
 
+instance (Ord key, KnownVal [(key,val)] pairs) => KnownVal (DM.Map key val) (pairs :: [(key',val')])
+  where
+    fromType _ = DM.fromList (fromType (Proxy @pairs))
+
 --------------------------------------------------------------------------------
 
 -- Set
 
-instance (Ord typ, KnownVal [typ] kind) => KnownVal (S.Set typ) ('FS.Set kind)
+instance (Ord val, KnownVal [val] kind) => KnownVal (S.Set val) ('FS.Set kind)
+  where
+    fromType _ = S.fromList (fromType (Proxy @kind))
+
+instance (Ord val, KnownVal [val] kind) => KnownVal (S.Set val) (kind :: [kind'])
   where
     fromType _ = S.fromList (fromType (Proxy @kind))
  
@@ -201,3 +188,19 @@ instance (KnownVal a1 a, KnownVal b1 b, KnownVal c1 c, KnownVal d1 d) => KnownVa
 
 instance (KnownVal a1 a, KnownVal b1 b, KnownVal c1 c, KnownVal d1 d, KnownVal e1 e) => KnownVal (a1,b1,c1,d1,e1) '(a,b,c,d,e) where
     fromType _ = (fromType @a1 (Proxy @a), fromType @b1 (Proxy @b), fromType @c1 (Proxy @c), fromType @d1 (Proxy @d), fromType @e1 (Proxy @e))
+
+--------------------------------------------------------------------------------
+
+-- ErrorMessage from GHC.TypeLits
+
+instance (IsString str, KnownSymbol sym) => KnownVal str ('TL.Text sym) where
+  fromType _ = fromType @str (Proxy @sym)
+
+instance (IsString str, Typeable typ) => KnownVal str ('TL.ShowType typ) where
+  fromType _ = fromString $ show $ typeRep (Proxy @typ)
+
+instance (IsString str, KnownVal str err1, KnownVal str err2, Semigroup str) => KnownVal str (err1 'TL.:<>: err2) where
+  fromType _ = fromType (Proxy @err1) <> fromType (Proxy @err2)
+
+instance (IsString str, KnownVal str err1, KnownVal str err2, Semigroup str) => KnownVal str (err1 'TL.:$$: err2) where
+  fromType _ = fromType (Proxy @err1) <> fromString "\n" <> fromType (Proxy @err2)

--- a/src/Fcf/Data/Reflect.hs
+++ b/src/Fcf/Data/Reflect.hs
@@ -60,6 +60,37 @@ import qualified Fcf.Data.Tree as FT
 
 --------------------------------------------------------------------------------
 
+
+-- | Reflect a list of Nats
+--
+-- Note that you may also use the KnownVal methods given below.
+--
+-- This method is taken from
+-- https://hackage.haskell.org/package/numhask-array-0.10.1/docs/src/NumHask.Array.Shape.html#natVals
+--
+-- === __Example__
+--
+-- >>> :{
+-- afun :: forall n. (n ~ '[1,2,3,4]) => [Int]
+-- afun = natVals @n Proxy
+-- :}
+--
+-- >>> afun
+-- [1,2,3,4]
+class KnownNats (ns :: [Nat]) where
+  natVals :: Proxy ns -> [Int]
+
+{-# DEPRECATED KnownNats "Replaced with KnownVal" #-}
+
+instance KnownNats '[] where
+  natVals _ = []
+
+instance (TL.KnownNat n, KnownNats ns) => KnownNats (n : ns) where
+  natVals _ = fromInteger (TL.natVal (Proxy @n)) : natVals (Proxy @ns)
+
+
+--------------------------------------------------------------------------------
+
 class KnownVal val kind where
     fromType :: Proxy kind -> val
 

--- a/src/Fcf/Data/Reflect.hs
+++ b/src/Fcf/Data/Reflect.hs
@@ -73,8 +73,10 @@ instance KnownVal () '() where fromType _ = ()
 instance (IsString str, KnownSymbol s) => KnownVal str (s :: Symbol) where
     fromType _ = fromString $ TL.symbolVal (Proxy @s)
 
+#if __GLASGOW_HASKELL__ >= 920
 instance (TL.KnownChar c) => KnownVal Char c where
     fromType _ = TL.charVal (Proxy @c)
+#endif
 
 instance (IsString str, Typeable typ) => KnownVal str (typ :: Type) where
     fromType = fromString . show . typeRep

--- a/test/Test/Data/Reflect.hs
+++ b/test/Test/Data/Reflect.hs
@@ -14,9 +14,7 @@ import qualified Data.IntMap as IM
 import qualified Data.Map as DM
 import qualified Data.Set as DS
 import qualified Data.Tree as DT
-#if __GLASGOW_HASKELL__ >= 902
 import qualified Data.Text as DTxt
-#endif
 import qualified GHC.TypeLits as TL
 import           Data.Proxy
 import           Test.Hspec (describe, it, shouldBe, Spec)
@@ -136,10 +134,12 @@ specStructures = describe "Maps and other structures" $ do
           test = fromType (Proxy @r)
       test `shouldBe` [(True,5),(False,6)]
   describe "IntMap" $ do
+#if __GLASGOW_HASKELL__ >= 920
     it "IntMap char, from '[ '(Nat,Char) ]" $ do
       let test :: forall r. (r ~ '[ '(1,'H'), '(2,'e'), '(5,'o'), '(3,'b'), '(4,'l'), '(3,'l')]) => IM.IntMap Char
           test = fromType (Proxy @r)
       test `shouldBe` IM.fromList [(1,'H'),(2,'e'),(5,'o'),(4,'l'),(3,'l')]
+#endif
     it "IntMap String, from NatMap" $ do
       let test :: forall r. (r ~ Eval (FNM.FromList '[ '(1,"H"), '(4,"b"), '(2,"e"), '(5,"o"), '(4,"l"), '(3,"l")])) => IM.IntMap String
           test = fromType (Proxy @r)
@@ -154,10 +154,12 @@ specStructures = describe "Maps and other structures" $ do
         `shouldBe` 
         IM.fromList [ (3, "hih"), (1, "haa"), (2, "hoo")]
   describe "Map" $ do
+#if __GLASGOW_HASKELL__ >= 920
     it "Map Int char, from '[ '(Nat,Char) ]" $ do
       let test :: forall r. (r ~ '[ '(1,'H'), '(2,'e'), '(5,'o'), '(4,'l'), '(3,'b'), '(3,'l')]) => DM.Map Int Char
           test = fromType (Proxy @r)
       test `shouldBe` DM.fromList [(1,'H'),(2,'e'),(5,'o'),(4,'l'),(3,'l')]
+#endif
     it "Map Int String, from MapC" $ do
       let test :: forall r. (r ~ Eval (FNMC.FromList '[ '(1,"H"), '(2,"e"), '(3,"c"), '(5,"o"), '(4,"l"), '(3,"l")])) => DM.Map Int String
           test = fromType (Proxy @r)
@@ -172,10 +174,12 @@ specStructures = describe "Maps and other structures" $ do
         `shouldBe` 
         DM.fromList [ (3, "hih"), (1, "haa"), (2, "hoo")]
   describe "Set" $ do
+#if __GLASGOW_HASKELL__ >= 920
     it "Set char, from '[Char]" $ do
       let test :: forall r. (r ~ '[ 'H','e','o','l','l' ]) => DS.Set Char
           test = fromType (Proxy @r)
       test `shouldBe` DS.fromList ['H','e','o','l','l']
+#endif
     it "Set String, from Set" $ do
       let test :: forall r. (r ~ Eval (FS.FromList '["H","e","o","l","l"])) => DS.Set String
           test = fromType (Proxy @r)


### PR DESCRIPTION
Two important changes:

1. I added instances to IntMap, Map and Set to convert directly from `'[a]` or `'[ '(key,val) ]`
2. I removed `KnownNats`

I'm not sure what you wanted to use `KnownNats` for since `KnownVal` handled those cases. I thought it would be less confusing to just have one type class. At the same time, I am removing a class you wrote. If you want to keep it there, let me know and I'll put it back in the PR.

The `ErrorMessage` instance I wanted so I could show all of my types.